### PR TITLE
Use tab duplication hack for private protocol in Pale Moon 28.1+ and Basilisk

### DIFF
--- a/protocol.jsm
+++ b/protocol.jsm
@@ -145,7 +145,9 @@ var privateProtocol = {
 		}
 		catch(e) {
 			if( // See https://github.com/Infocatcher/Private_Tab/issues/251
-				this.platformVersion >= 52
+				(this.platformVersion >= 52
+				|| Services.appinfo.name == "Pale Moon" && this.platformVersion >= 4.1
+				|| Services.appinfo.name == "Basilisk")
 				&& this.fixTabFromLoadContext(loadContext, channel.URI.ref)
 			)
 				return undefined;


### PR DESCRIPTION
Tag #251. The fix is based on https://github.com/Infocatcher/Private_Tab/commit/5148b80b7c8a1ec52f0513a3dbb6d7fcaed0d64f.